### PR TITLE
Fix payment not recorded after Paystack checkout redirect

### DIFF
--- a/class/actions_paystack.class.php
+++ b/class/actions_paystack.class.php
@@ -50,17 +50,18 @@ class ActionsPaystack
      * @param string  $action     Action
      * @return int                0
      */
-    public function getValidPayment($parameters, &$object, &$action)
+    public function getValidPayment(&$parameters, &$object, &$action)
     {
         global $conf;
 
         // Only add if module is enabled
         if (!empty($conf->paystack->enabled)) {
-            // Register paystack in the validpaymentmethod array
-            if (isset($parameters['validpaymentmethod'])) {
-                $parameters['validpaymentmethod']['paystack'] = 'paystack';
-            }
-            
+            // Register paystack in the validpaymentmethod array.
+            // We modify $parameters (by reference) AND set $this->results because
+            // Dolibarr HookManager reads from both depending on version.
+            $parameters['validpaymentmethod']['paystack'] = 'paystack';
+            $this->results['validpaymentmethod']['paystack'] = 'paystack';
+
             dol_syslog("Paystack: Registered as valid payment method", LOG_DEBUG);
         }
 
@@ -424,28 +425,48 @@ class ActionsPaystack
             
             if ($http_code == 200) {
                 $result = json_decode($response, true);
-                
-                if ($result['status'] === true && 
-                    isset($result['data']['status']) && 
+
+                if ($result['status'] === true &&
+                    isset($result['data']['status']) &&
                     $result['data']['status'] === 'success') {
-                    
+
                     // Payment verified successfully!
                     $amount = $result['data']['amount'] / 100;
                     $currency = isset($result['data']['currency']) ? $result['data']['currency'] : 'NGN';
-                    
+
                     dol_syslog("Paystack: Payment SUCCESSFUL - Ref: ".$reference.", Amount: ".$amount." ".$currency, LOG_INFO);
-                    
+
                     // Set result
                     $this->results['ispaymentok'] = true;
-                    
+
+                    // CRITICAL: Restore FULLTAG from URL if the session was lost during
+                    // the external redirect to Paystack (cross-domain SameSite cookie issue).
+                    // paymentok.php requires FULLTAG in session to record the payment.
+                    $fulltag_from_url = GETPOST('fulltag', 'alpha');
+                    if (!empty($fulltag_from_url)) {
+                        if (empty($_SESSION['FULLTAG'])) {
+                            $_SESSION['FULLTAG'] = $fulltag_from_url;
+                        }
+                        if (empty($_SESSION['fulltag'])) {
+                            $_SESSION['fulltag'] = $fulltag_from_url;
+                        }
+                        if (empty($_SESSION['FULLTAGpaystack'])) {
+                            $_SESSION['FULLTAGpaystack'] = $fulltag_from_url;
+                        }
+                        dol_syslog("Paystack: FULLTAG restored from URL - ".$fulltag_from_url, LOG_INFO);
+                    }
+
                     // Update session variables - CRITICAL for Dolibarr
                     $_SESSION['TRANSACTIONID'] = $reference;
                     $_SESSION['FinalPaymentAmt'] = $amount;
                     $_SESSION['currencyCodeType'] = $currency;
+                    if (empty($_SESSION['paymentmethod'])) {
+                        $_SESSION['paymentmethod'] = 'paystack';
+                    }
                     $_SESSION['PAYMENTMETHOD'] = 'paystack';
-                    
-                    dol_syslog("Paystack: Session variables set - Payment will be recorded", LOG_INFO);
-                    
+
+                    dol_syslog("Paystack: Session variables set - FULLTAG=".(!empty($_SESSION['FULLTAG']) ? $_SESSION['FULLTAG'] : 'MISSING'), LOG_INFO);
+
                     return 0;
                 } else {
                     $status = isset($result['data']['status']) ? $result['data']['status'] : 'unknown';

--- a/core/modules/modPaystack.class.php
+++ b/core/modules/modPaystack.class.php
@@ -61,7 +61,10 @@ class modPaystack extends DolibarrModules
         
         // Module parts - hooks for payment integration
         $this->module_parts = array(
-            'hooks' => array('newpayment', 'paystack')  // Hook into payment page
+            // 'newpayment' - getValidPayment, doAddButton, doPayment hooks on payment form
+            // 'paymentok'  - isPaymentOK hook called by paymentok.php after redirect back
+            // 'paystack'   - module-specific context (keep for backward compat)
+            'hooks' => array('newpayment', 'paymentok', 'paystack')
         );
         
         // Data directories


### PR DESCRIPTION
Three bugs prevented Dolibarr from recording successful Paystack payments:

1. getValidPayment hook: $parameters was passed by value, so registering 'paystack' as a valid payment method had no effect. Fixed by passing $parameters by reference and also setting $this->results for compatibility with all Dolibarr HookManager versions.

2. Session loss on redirect: After the external Paystack redirect, PHP session could be lost due to cross-domain SameSite cookie restrictions. isPaymentOK now restores FULLTAG and paymentmethod from the URL parameters when the session is missing, so paymentok.php can still record the payment.

3. Missing paymentok hook context: isPaymentOK is called by paymentok.php under the 'paymentok' context, which was not registered. Added 'paymentok' to the module hooks array so the verification hook is actually triggered.

Fixes: payment appears successful in Paystack but is not recorded in Dolibarr.